### PR TITLE
Made changes based on tkim1210's advice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,22 @@ reports/report.html: $(RESULTS_DIR)/boxplots.png $(VIF_TABLE) $(METRICS_FILE) $(
 
 # Clean
 clean:
-	rm -rf data results reports/*.html
+	# remove processed data, keep raw data
+	rm -rf data/processed/*
+
+	# remove all results (figures, tables, model outputs)
+	rm -rf results/*
+
+	# remove rendered reports
+	rm -f reports/*.html
+	rm -f reports/*.pdf
+
+	# remove Quarto cache
+	rm -rf .quarto/
+
+	# remove LaTeX intermediate files
+	find . -name "*.aux" -delete
+	find . -name "*.log" -delete
+	find . -name "*.tex" -delete
 
 .PHONY: all clean dirs

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ R -e "renv::restore()"
 3. Run the analysis:
 make all 
 
+## How to Run Tests
+
+To run all the tests located in `tests` folder, run the following code from the root directory:
+
+```
+testthat::test_dir("tests/testthat")
+```
+
+If you wanted to run an individual test file, run the following code from the root directory:
+
+```
+testthat::test_file("tests/testthat/your_file_of_interest")
+```
+
 ## Project Structure
 
 - `src/airbnb_price_analysis.ipynb`: original analysis notebook

--- a/README.md
+++ b/README.md
@@ -90,20 +90,6 @@ R -e "renv::restore()"
 3. Run the analysis:
 make all 
 
-## How to Run Tests
-
-To run all the tests located in `tests` folder, run the following code from the root directory:
-
-```
-testthat::test_dir("tests/testthat")
-```
-
-If you wanted to run an individual test file, run the following code from the root directory:
-
-```
-testthat::test_file("tests/testthat/your_file_of_interest")
-```
-
 ## Project Structure
 
 - `src/airbnb_price_analysis.ipynb`: original analysis notebook

--- a/src/01_download_airbnb_data.R
+++ b/src/01_download_airbnb_data.R
@@ -4,6 +4,10 @@
 # This script downloads Airbnb data from the InsideAirbnb website URL: 
 # "https://data.insideairbnb.com/canada/bc/vancouver/2025-11-17/data/listings.csv.gz"
 #
+# If the script does not function correctly because of the url being invalid/outdated, 
+# please obtain the most version by heading to the website URL:
+# https://insideairbnb.com/get-the-data/
+#
 # It outputs a raw dataset. 
 #
 # Usage:

--- a/src/01_download_airbnb_data.R
+++ b/src/01_download_airbnb_data.R
@@ -8,6 +8,9 @@
 # please obtain the most version by heading to the website URL:
 # https://insideairbnb.com/get-the-data/
 #
+# If the website URL is also invalid, please use the copy of the raw data located in
+# data/raw for future analysis steps.
+#
 # It outputs a raw dataset. 
 #
 # Usage:


### PR DESCRIPTION
The following changes were based of tkim1210's comments:

1. tkim1210 noted that the link used to install raw data may become invalid in the future. Thus, a copy of the raw data is located in `data/raw` in case this happens. 

2. tkim1210 requested to add clearer instructions for running tests. Instructions were added in `README.md` with appropriate code blocks. 
 
3. tkim1210 noted that some figures remain after running `make clean`, however I did not encounter this issue. If possible, please check if this issue is reproducible on your side. 